### PR TITLE
Reorder extra env vars for proper interdependent env variable access

### DIFF
--- a/charts/hasura/templates/deployment.yaml
+++ b/charts/hasura/templates/deployment.yaml
@@ -38,15 +38,15 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.extraEnvVars }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "hasura.fullname" . }}
             - secretRef:
                 name: {{ include "hasura.fullname" . }}
-          {{- with .Values.extraEnvVars }}
-          env:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.serverPort }}


### PR DESCRIPTION
Ref: https://kubernetes.io/docs/tasks/inject-data-application/define-interdependent-environment-variables/

> Note that order matters in the env list. An environment variable is not considered "defined" if it is specified further down the list. That is why UNCHANGED_REFERENCE fails to resolve $(PROTOCOL) in the example above.

Apparently the order of importing/defining variables matters. Since `PG_PASSWORD` is defined as an extra variable and reused by the secret variables it has to be defined first.