### PR TITLE
feat: add istio gateway helm chart

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: gateway
+description: Helm chart for deploying Istio gateways
+type: application
+
+# This version is never actually shipped. istio/release-builder will replace it at build-time
+# with the appropriate version
+version: 1.19.1
+appVersion: 1.19.0
+
+sources:
+- https://github.com/istio/istio
+icon: https://istio.io/latest/favicons/android-192x192.png
+keywords:
+- istio
+- gateways

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -1,0 +1,156 @@
+# Istio Gateway Helm Chart
+
+This chart installs an Istio gateway deployment.
+
+## Setup Repo Info
+
+```console
+helm repo add istio https://istio-release.storage.googleapis.com/charts
+helm repo update
+```
+
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
+
+## Installing the Chart
+
+To install the chart with the release name `istio-ingressgateway`:
+
+```console
+helm install istio-ingressgateway istio/gateway
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `istio-ingressgateway` deployment:
+
+```console
+helm delete istio-ingressgateway
+```
+
+## Configuration
+
+To view support configuration options and documentation, run:
+
+```console
+helm show values istio/gateway
+```
+
+### OpenShift
+
+When deploying the gateway in an OpenShift cluster, use the `openshift-values.yaml` file to override the default values, for example:
+
+```console
+helm install istio-ingressgateway istio/gateway -f openshift-values.yaml
+```
+
+### `image: auto` Information
+
+The image used by the chart, `auto`, may be unintuitive.
+This exists because the pod spec will be automatically populated at runtime, using the same mechanism as [Sidecar Injection](istio.io/latest/docs/setup/additional-setup/sidecar-injection).
+This allows the same configurations and lifecycle to apply to gateways as sidecars.
+
+Note: this does mean that the namespace the gateway is deployed in must not have the `istio-injection=disabled` label.
+See [Controlling the injection policy](https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#controlling-the-injection-policy) for more info.
+
+### Examples
+
+#### Egress Gateway
+
+Deploying a Gateway to be used as an [Egress Gateway](https://istio.io/latest/docs/tasks/traffic-management/egress/egress-gateway/):
+
+```yaml
+service:
+  # Egress gateways do not need an external LoadBalancer IP
+  type: ClusterIP
+```
+
+#### Multi-network/VM Gateway
+
+Deploying a Gateway to be used as a [Multi-network Gateway](https://istio.io/latest/docs/setup/install/multicluster/) for network `network-1`:
+
+```yaml
+networkGateway: network-1
+```
+
+### Migrating from other installation methods
+
+Installations from other installation methods (such as istioctl, Istio Operator, other helm charts, etc) can be migrated to use the new Helm charts
+following the guidance below.
+If you are able to, a clean installation is simpler. However, this often requires an external IP migration which can be challenging.
+
+WARNING: when installing over an existing deployment, the two deployments will be merged together by Helm, which may lead to unexpected results.
+
+#### Legacy Gateway Helm charts
+
+Istio historically offered two different charts - `manifests/charts/gateways/istio-ingress` and `manifests/charts/gateways/istio-egress`.
+These are replaced by this chart.
+While not required, it is recommended all new users use this chart, and existing users migrate when possible.
+
+This chart has the following benefits and differences:
+* Designed with Helm best practices in mind (standardized values options, values schema, values are not all nested under `gateways.istio-ingressgateway.*`, release name and namespace taken into account, etc).
+* Utilizes Gateway injection, simplifying upgrades, allowing gateways to run in any namespace, and avoiding repeating config for sidecars and gateways.
+* Published to official Istio Helm repository.
+* Single chart for all gateways (Ingress, Egress, East West).
+
+#### General concerns
+
+For a smooth migration, the resource names and `Deployment.spec.selector` labels must match.
+
+If you install with `helm install istio-gateway istio/gateway`, resources will be named `istio-gateway` and the `selector` labels set to:
+
+```yaml
+app: istio-gateway
+istio: gateway # the release name with leading istio- prefix stripped
+```
+
+If your existing installation doesn't follow these names, you can override them. For example, if you have resources named `my-custom-gateway` with `selector` labels
+`foo=bar,istio=ingressgateway`:
+
+```yaml
+name: my-custom-gateway # Override the name to match existing resources
+labels:
+  app: "" # Unset default app selector label
+  istio: ingressgateway # override default istio selector label
+  foo: bar # Add the existing custom selector label
+```
+
+#### Migrating an existing Helm release
+
+An existing helm release can be `helm upgrade`d to this chart by using the same release name. For example, if a previous
+installation was done like:
+
+```console
+helm install istio-ingress manifests/charts/gateways/istio-ingress -n istio-system
+```
+
+It could be upgraded with
+
+```console
+helm upgrade istio-ingress manifests/charts/gateway -n istio-system --set name=istio-ingressgateway --set labels.app=istio-ingressgateway --set labels.istio=ingressgateway
+```
+
+Note the name and labels are overridden to match the names of the existing installation.
+
+Warning: the helm charts here default to using port 80 and 443, while the old charts used 8080 and 8443.
+If you have AuthorizationPolicies that reference port these ports, you should update them during this process,
+or customize the ports to match the old defaults.
+See the [security advisory](https://istio.io/latest/news/security/istio-security-2021-002/) for more information.
+
+#### Other migrations
+
+If you see errors like `rendered manifests contain a resource that already exists` during installation, you may need to forcibly take ownership.
+
+The script below can handle this for you. Replace `RELEASE` and `NAMESPACE` with the name and namespace of the release:
+
+```console
+KINDS=(service deployment)
+RELEASE=istio-ingressgateway
+NAMESPACE=istio-system
+for KIND in "${KINDS[@]}"; do
+    kubectl --namespace $NAMESPACE --overwrite=true annotate $KIND $RELEASE meta.helm.sh/release-name=$RELEASE
+    kubectl --namespace $NAMESPACE --overwrite=true annotate $KIND $RELEASE meta.helm.sh/release-namespace=$NAMESPACE
+    kubectl --namespace $NAMESPACE --overwrite=true label $KIND $RELEASE app.kubernetes.io/managed-by=Helm
+done
+```
+
+You may ignore errors about resources not being found.

--- a/charts/gateway/openshift-values.yaml
+++ b/charts/gateway/openshift-values.yaml
@@ -1,0 +1,8 @@
+containerSecurityContext:
+  capabilities:
+    drop:
+    - ALL
+  allowPrivilegeEscalation: false
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true

--- a/charts/gateway/templates/NOTES.txt
+++ b/charts/gateway/templates/NOTES.txt
@@ -1,0 +1,9 @@
+"{{ include "gateway.name" . }}" successfully installed!
+
+To learn more about the release, try:
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+
+Next steps:
+  * Deploy an HTTP Gateway: https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/
+  * Deploy an HTTPS Gateway: https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{- define "gateway.name" -}}
+{{- if eq .Release.Name "RELEASE-NAME" -}}
+  {{- .Values.name | default "istio-ingressgateway" -}}
+{{- else -}}
+  {{- .Values.name | default .Release.Name | default "istio-ingressgateway" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "gateway.labels" -}}
+helm.sh/chart: {{ include "gateway.chart" . }}
+{{ include "gateway.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ include "gateway.name" . }}
+{{- range $key, $val := .Values.labels }}
+{{- if not (or (eq $key "app") (eq $key "istio")) }}
+{{ $key | quote }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "gateway.podLabels" -}}
+{{ include "gateway.selectorLabels" . }}
+{{- range $key, $val := .Values.labels }}
+{{- if not (or (eq $key "app") (eq $key "istio")) }}
+{{ $key | quote }}: {{ $val | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "gateway.selectorLabels" -}}
+{{- if hasKey .Values.labels "app" }}
+{{- with .Values.labels.app }}app: {{.|quote}}
+{{- end}}
+{{- else }}app: {{ include "gateway.name" . }}
+{{- end }}
+{{- if hasKey .Values.labels "istio" }}
+{{- with .Values.labels.istio }}
+istio: {{.|quote}}
+{{- end}}
+{{- else }}
+istio: {{ include "gateway.name" . | trimPrefix "istio-" }}
+{{- end }}
+{{- end }}
+
+{{- define "gateway.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- .Values.serviceAccount.name | default (include "gateway.name" .)    }}
+{{- else }}
+{{- .Values.serviceAccount.name | default "default" }}
+{{- end }}
+{{- end }}

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: {{ .Values.kind | default "Deployment" }}
+metadata:
+  name: {{ include "gateway.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway.labels" . | nindent 4}}
+  annotations:
+    {{- .Values.annotations | toYaml | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  {{- with .Values.replicaCount }}
+  replicas: {{ . }}
+  {{- end }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "gateway.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        sidecar.istio.io/inject: "true"
+        {{- with .Values.revision }}
+        istio.io/rev: {{ . }}
+        {{- end }}
+        {{- include "gateway.podLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "gateway.serviceAccountName" . }}
+      securityContext:
+      {{- if .Values.securityContext }}
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- else if (semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion) }}
+        # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
+      {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: istio-proxy
+          # "auto" will be populated at runtime by the mutating webhook. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#customizing-injection
+          image: auto
+          {{- with .Values.imagePullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
+          securityContext:
+          {{- if .Values.containerSecurityContext }}
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- else if (semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion) }}
+            # Safe since 1.22: https://github.com/kubernetes/kubernetes/pull/103326
+            capabilities:
+              drop:
+              - ALL
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1337
+            runAsGroup: 1337
+            runAsNonRoot: true
+          {{- else }}
+            capabilities:
+              drop:
+              - ALL
+              add:
+              - NET_BIND_SERVICE
+            runAsUser: 0
+            runAsGroup: 1337
+            runAsNonRoot: false
+            allowPrivilegeEscalation: true
+            readOnlyRootFilesystem: true
+          {{- end }}
+          env:
+          {{- with .Values.networkGateway }}
+          - name: ISTIO_META_REQUESTED_NETWORK_VIEW
+            value: "{{.}}"
+          {{- end }}
+          {{- range $key, $val := .Values.env }}
+          - name: {{ $key }}
+            value: {{ $val | quote }}
+          {{- end }}
+          ports:
+          - containerPort: 15090
+            protocol: TCP
+            name: http-envoy-prom
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{ toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds }}

--- a/charts/gateway/templates/hpa.yaml
+++ b/charts/gateway/templates/hpa.yaml
@@ -1,0 +1,31 @@
+{{- if and (.Values.autoscaling.enabled) (eq .Values.kind "Deployment") }}
+{{- if (semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion)}}
+apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta2
+{{- end }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "gateway.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway.labels" . | nindent 4 }}
+  annotations:
+    {{- .Values.annotations | toYaml | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: {{ .Values.kind | default "Deployment" }}
+    name: {{ include "gateway.name" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+          type: Utilization
+    {{- end }}
+{{- end }}

--- a/charts/gateway/templates/poddisruptionbudget.yaml
+++ b/charts/gateway/templates/poddisruptionbudget.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.podDisruptionBudget }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "gateway.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway.labels" . | nindent 4}}
+spec:
+  selector:
+    matchLabels:
+  {{- include "gateway.selectorLabels" . | nindent 6 }}
+  {{- with .Values.podDisruptionBudget }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/gateway/templates/role.yaml
+++ b/charts/gateway/templates/role.yaml
@@ -1,0 +1,33 @@
+{{/*Set up roles for Istio Gateway. Not required for gateway-api*/}}
+{{- if .Values.rbac.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "gateway.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway.labels" . | nindent 4}}
+  annotations:
+    {{- .Values.annotations | toYaml | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "gateway.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway.labels" . | nindent 4}}
+  annotations:
+    {{- .Values.annotations | toYaml | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "gateway.serviceAccountName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "gateway.serviceAccountName" . }}
+{{- end }}

--- a/charts/gateway/templates/service.yaml
+++ b/charts/gateway/templates/service.yaml
@@ -1,0 +1,57 @@
+{{- if not (eq .Values.service.type "None") }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gateway.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway.labels" . | nindent 4 }}
+    {{- with .Values.networkGateway }}
+    topology.istio.io/network: "{{.}}"
+    {{- end }}
+  annotations:
+    {{- merge (deepCopy .Values.service.annotations) .Values.annotations | toYaml | nindent 4 }}
+spec:
+{{- with .Values.service.loadBalancerIP }}
+  loadBalancerIP: "{{ . }}"
+{{- end }}
+{{- with .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: "{{ . }}"
+{{- end }}
+{{- with .Values.service.ipFamilies }}
+  ipFamilies:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: "{{ . }}"
+{{- end }}
+  type: {{ .Values.service.type }}
+  ports:
+{{- if .Values.networkGateway }}
+  - name: status-port
+    port: 15021
+    targetPort: 15021
+  - name: tls
+    port: 15443
+    targetPort: 15443
+  - name: tls-istiod
+    port: 15012
+    targetPort: 15012
+  - name: tls-webhook
+    port: 15017
+    targetPort: 15017
+{{- else }}
+{{ .Values.service.ports | toYaml | indent 4 }}
+{{- end }}
+{{- if .Values.service.externalIPs }}
+  externalIPs: {{- range .Values.service.externalIPs }}
+    - {{.}}
+  {{- end }}
+{{- end }}
+  selector:
+    {{- include "gateway.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/gateway/templates/serviceaccount.yaml
+++ b/charts/gateway/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "gateway.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gateway.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/gateway/values.schema.json
+++ b/charts/gateway/values.schema.json
@@ -1,0 +1,244 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "global": {
+      "type": "object"
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": ["object", "null"]
+    },
+    "containerSecurityContext": {
+      "type": ["object", "null"]
+    },
+    "kind":{
+      "type": "string",
+      "enum": ["Deployment", "DaemonSet"]
+    },
+    "annotations": {
+      "additionalProperties": {
+        "type": [
+          "string",
+          "integer"
+        ]
+      },
+      "type": "object"
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "maxReplicas": {
+          "type": "integer"
+        },
+        "minReplicas": {
+          "type": "integer"
+        },
+        "targetCPUUtilizationPercentage": {
+          "type": "integer"
+        }
+      }
+    },
+    "env": {
+      "type": "object"
+    },
+    "labels": {
+      "type": "object"
+    },
+    "name": {
+      "type": "string"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "podAnnotations": {
+      "type": "object",
+      "properties": {
+        "inject.istio.io/templates": {
+          "type": "string"
+        },
+        "prometheus.io/path": {
+          "type": "string"
+        },
+        "prometheus.io/port": {
+          "type": "string"
+        },
+        "prometheus.io/scrape": {
+          "type": "string"
+        }
+      }
+    },
+    "replicaCount": {
+      "type": [ "integer", "null" ]
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          }
+        },
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "revision": {
+      "type": "string"
+    },
+    "runAsRoot": {
+      "type": "boolean"
+    },
+    "unprivilegedPort": {
+      "type": ["string", "boolean"],
+      "enum": [true, false, "auto"]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "externalTrafficPolicy": {
+          "type": "string"
+        },
+        "loadBalancerIP": {
+          "type": "string"
+        },
+        "loadBalancerSourceRanges": {
+          "type": "array"
+        },
+        "ipFamilies" : {
+          "items": {
+            "type": "string",
+            "enum": ["IPv4", "IPv6"]
+        }
+        },
+        "ipFamilyPolicy" : {
+          "type": "string",
+          "enum": ["", "SingleStack", "PreferDualStack", "RequireDualStack"]
+        },
+        "ports": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer"
+              },
+              "protocol": {
+                "type": "string"
+              },
+              "targetPort": {
+                "type": "integer"
+              }
+            }
+          }
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "create": {
+          "type": "boolean"
+        }
+      }
+    },
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "topologySpreadConstraints": {
+      "type": "array"
+    },
+    "networkGateway": {
+      "type": "string"
+    },
+    "imagePullPolicy": {
+      "type": "string",
+      "enum": ["", "Always", "IfNotPresent", "Never"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "minAvailable": {
+          "type": ["integer", "string"]
+        },
+        "maxUnavailable": {
+          "type": ["integer", "string"]
+        },
+        "unhealthyPodEvictionPolicy": {
+          "type": "string",
+          "enum": ["", "IfHealthyBudget", "AlwaysAllow"]
+        }
+      }
+    },
+    "terminationGracePeriodSeconds": {
+      "type": "number"
+    },
+    "volumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "volumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -1,0 +1,141 @@
+# Name allows overriding the release name. Generally this should not be set
+name: ""
+# revision declares which revision this gateway is a part of
+revision: ""
+
+# Controls the spec.replicas setting for the Gateway deployment if set.
+# Otherwise defaults to Kubernetes Deployment default (1).
+replicaCount:
+
+kind: Deployment
+
+rbac:
+  # If enabled, roles will be created to enable accessing certificates from Gateways. This is not needed
+  # when using http://gateway-api.org/.
+  enabled: true
+
+serviceAccount:
+  # If set, a service account will be created. Otherwise, the default is used
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set, the release name is used
+  name: ""
+
+podAnnotations:
+  prometheus.io/port: "15020"
+  prometheus.io/scrape: "true"
+  prometheus.io/path: "/stats/prometheus"
+  inject.istio.io/templates: "gateway"
+  sidecar.istio.io/inject: "true"
+
+# Define the security context for the pod.
+# If unset, this will be automatically set to the minimum privileges required to bind to port 80 and 443.
+# On Kubernetes 1.22+, this only requires the `net.ipv4.ip_unprivileged_port_start` sysctl.
+securityContext: ~
+containerSecurityContext: ~
+
+service:
+  # Type of service. Set to "None" to disable the service entirely
+  type: LoadBalancer
+  ports:
+  - name: status-port
+    port: 15021
+    protocol: TCP
+    targetPort: 15021
+  - name: http2
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  annotations: {}
+  loadBalancerIP: ""
+  loadBalancerSourceRanges: []
+  externalTrafficPolicy: ""
+  externalIPs: []
+  ipFamilyPolicy: ""
+  ipFamilies: []
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 2000m
+    memory: 1024Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+
+# Pod environment variables
+env: {}
+
+# Labels to apply to all resources
+labels: {}
+
+# Annotations to apply to all resources
+annotations: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+topologySpreadConstraints: []
+
+affinity: {}
+
+# If specified, the gateway will act as a network gateway for the given network.
+networkGateway: ""
+
+# Specify image pull policy if default behavior isn't desired.
+# Default behavior: latest images will be Always else IfNotPresent
+imagePullPolicy: ""
+
+imagePullSecrets: []
+
+# This value is used to configure a Kubernetes PodDisruptionBudget for the gateway.
+#
+# By default, the `podDisruptionBudget` is disabled (set to `{}`),
+# which means that no PodDisruptionBudget resource will be created.
+#
+# To enable the PodDisruptionBudget, configure it by specifying the
+# `minAvailable` or `maxUnavailable`. For example, to set the
+# minimum number of available replicas to 1, you can update this value as follows:
+#
+# podDisruptionBudget:
+#   minAvailable: 1
+#
+# Or, to allow a maximum of 1 unavailable replica, you can set:
+#
+# podDisruptionBudget:
+#   maxUnavailable: 1
+#
+# You can also specify the `unhealthyPodEvictionPolicy` field, and the valid values are `IfHealthyBudget` and `AlwaysAllow`.
+# For example, to set the `unhealthyPodEvictionPolicy` to `AlwaysAllow`, you can update this value as follows:
+#
+# podDisruptionBudget:
+#   minAvailable: 1
+#   unhealthyPodEvictionPolicy: AlwaysAllow
+#
+# To disable the PodDisruptionBudget, you can leave it as an empty object `{}`:
+#
+# podDisruptionBudget: {}
+#
+podDisruptionBudget: {}
+
+terminationGracePeriodSeconds: 30
+
+# A list of `Volumes` added into the Gateway Pods. See
+# https://kubernetes.io/docs/concepts/storage/volumes/.
+volumes: []
+
+# A list of `VolumeMounts` added into the Gateway Pods. See
+# https://kubernetes.io/docs/concepts/storage/volumes/.
+volumeMounts: []


### PR DESCRIPTION
Adds the Istio gateway Helm chart so we can temporarily use it until https://github.com/istio/istio/pull/45894 gets included in a released chart. The ability to add volumes is needed for the OAuth2 flow in the Kubeflow gateway. The regular gateway installation we do shouldn't need this.