### PR TITLE
Sentry: support TLS for Redis

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 - name: sentry-kubernetes
 name: sentry
 type: application
-version: 19.4.0
+version: 19.4.0+1

--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 - name: sentry-kubernetes
 name: sentry
 type: application
-version: 19.4.0+1
+version: 19.4.0-plural1

--- a/charts/sentry/templates/_helper.tpl
+++ b/charts/sentry/templates/_helper.tpl
@@ -276,6 +276,17 @@ Set redis port
 {{- end -}}
 
 {{/*
+Set redis protocol (rediss for TLS, redis for plaintext)
+*/}}
+{{- define "sentry.redis.protocol" -}}
+{{- if .Values.redis.enabled | ternary .Values.redis.tls.enabled .Values.externalRedis.tls -}}
+rediss
+{{- else -}}
+redis
+{{- end -}}
+{{- end -}}
+
+{{/*
 Set redis password
 */}}
 {{- define "sentry.redis.password" -}}

--- a/charts/sentry/templates/configmap-relay.yaml
+++ b/charts/sentry/templates/configmap-relay.yaml
@@ -1,6 +1,7 @@
 {{- $redisHost := include "sentry.redis.host" . -}}
 {{- $redisPort := include "sentry.redis.port" . -}}
 {{- $redisPass := include "sentry.redis.password" . -}}
+{{- $redisProtocol := include "sentry.redis.protocol" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -33,9 +34,9 @@ data:
           value: 50000000  # 50MB or bust
 
       {{- if $redisPass }}
-      redis: "redis://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}"
+      redis: {{ $redisProtocol }}://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}"
       {{- else }}
-      redis: "redis://{{ $redisHost }}:{{ $redisPort }}"
+      redis: {{ $redisProtocol }}://{{ $redisHost }}:{{ $redisPort }}"
       {{- end }}
       topics:
         metrics_transactions: ingest-performance-metrics

--- a/charts/sentry/templates/configmap-sentry.yaml
+++ b/charts/sentry/templates/configmap-sentry.yaml
@@ -1,6 +1,8 @@
 {{- $redisHost := include "sentry.redis.host" . -}}
 {{- $redisPort := include "sentry.redis.port" . -}}
 {{- $redisPass := include "sentry.redis.password" . -}}
+{{- $redisProtocol := include "sentry.redis.protocol" . -}}
+{{- $redisTls := eq "rediss" $redisProtocol -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -80,6 +82,9 @@ data:
             port: {{ $redisPort }}
             {{- if $redisPass }}
             password: {{ $redisPass | quote }}
+            {{- end }}
+            {{- if $redisTls }}
+            ssl: true
             {{- end }}
 
     ################
@@ -211,9 +216,9 @@ data:
     {{- if or (.Values.rabbitmq.enabled) (.Values.rabbitmq.host) }}
     BROKER_URL = os.environ.get("BROKER_URL", "amqp://{{ .Values.rabbitmq.auth.username }}:{{ .Values.rabbitmq.auth.password }}@{{ template "sentry.rabbitmq.host" . }}:5672/{{ .Values.rabbitmq.vhost }}")
     {{- else if $redisPass }}
-    BROKER_URL = os.environ.get("BROKER_URL", "redis://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/0")
+    BROKER_URL = os.environ.get("BROKER_URL", "{{ $redisProtocol }}://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}/0")
     {{- else }}
-    BROKER_URL = os.environ.get("BROKER_URL", "redis://{{ $redisHost }}:{{ $redisPort }}/0")
+    BROKER_URL = os.environ.get("BROKER_URL", "{{ $redisProtocol }}://{{ $redisHost }}:{{ $redisPort }}/0")
     {{- end }}
 
     #########

--- a/charts/sentry/templates/configmap-snuba.yaml
+++ b/charts/sentry/templates/configmap-snuba.yaml
@@ -1,4 +1,5 @@
 {{- $redisPass := include "sentry.redis.password" . -}}
+{{- $redisTls := eq "rediss" (include "sentry.redis.protocol" .) -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -70,6 +71,9 @@ data:
     REDIS_PASSWORD = {{ $redisPass | quote }}
     {{- end }}
     REDIS_DB = int(env("REDIS_DB", 1))
+    {{- if $redisTls }}
+    REDIS_SSL = True
+    {{- end }}
 
 {{- if .Values.metrics.enabled }}
     DOGSTATSD_HOST = "{{ template "sentry.fullname" . }}-metrics"

--- a/charts/sentry/values.yaml
+++ b/charts/sentry/values.yaml
@@ -226,6 +226,7 @@ externalPostgresql:
   username: postgres
 externalRedis:
   port: 6379
+  tls: false
 filestore:
   backend: filesystem
   filesystem:


### PR DESCRIPTION
This builds on top of import from #20 and makes it possible to configure a TLS connection to Redis