### PR TITLE
Bump chart-releaser-action for oci deps bugfix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           git checkout origin/gh-pages index.yaml
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.1
+        uses: helm/chart-releaser-action@v1.6.0
         with: 
           config: "./.github/configs/cr.yaml"
         env:


### PR DESCRIPTION
Last merge failed to publish the new chart with a null pointer dereference in chart-releaser: https://github.com/pluralsh/plural-helm-charts/actions/runs/6883003645/job/18722662961

The chart-releaser-action is pinned to 1.4.1, looking at the issues I found https://github.com/helm/chart-releaser/issues/225 (fixed in https://github.com/helm/chart-releaser/pull/226, fix released in v1.5.0). Sentry chart has OCI deps, so this should fix the publishing problem.