### PR TITLE
sentry: fix embarrassing typo in template text

### DIFF
--- a/charts/sentry/Chart.yaml
+++ b/charts/sentry/Chart.yaml
@@ -39,4 +39,4 @@ maintainers:
 - name: sentry-kubernetes
 name: sentry
 type: application
-version: 19.4.0-plural1
+version: 19.4.0-plural2

--- a/charts/sentry/templates/configmap-relay.yaml
+++ b/charts/sentry/templates/configmap-relay.yaml
@@ -34,9 +34,9 @@ data:
           value: 50000000  # 50MB or bust
 
       {{- if $redisPass }}
-      redis: {{ $redisProtocol }}://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}"
+      redis: "{{ $redisProtocol }}://:{{ $redisPass }}@{{ $redisHost }}:{{ $redisPort }}"
       {{- else }}
-      redis: {{ $redisProtocol }}://{{ $redisHost }}:{{ $redisPort }}"
+      redis: "{{ $redisProtocol }}://{{ $redisHost }}:{{ $redisPort }}"
       {{- end }}
       topics:
         metrics_transactions: ingest-performance-metrics


### PR DESCRIPTION
Should fix `sentry-relay` restart loop